### PR TITLE
testmerge cmd: --bootstrap-cwd flag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    singularity_dsl (2.0.0)
+    singularity_dsl (2.1.0)
       coveralls (~> 0.7.9)
       json (~> 1.0)
       mixlib-shellout (~> 2.0)
@@ -44,7 +44,7 @@ GEM
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
       rspec-mocks (~> 3.2.0)
-    rspec-core (3.2.1)
+    rspec-core (3.2.2)
       rspec-support (~> 3.2.0)
     rspec-expectations (3.2.0)
       diff-lcs (>= 1.2.0, < 2.0)

--- a/lib/singularity_dsl/cli.rb
+++ b/lib/singularity_dsl/cli.rb
@@ -69,10 +69,16 @@ EOD
              type: :string,
              desc: 'Run a batch instead, after testmerge.',
              default: ''
+      option :bootstrap_cwd,
+             aliases: '-b',
+             type: :boolean,
+             desc: 'Bootstrap local directory by cloning & setting up the repo.'
       def testmerge(git_fork, branch, base_branch, base_fork = nil)
-        Command::TestMerge.new(options)
-          .perform_merge(git_fork, branch, base_branch, base_fork)
-          .execute
+        Command::TestMerge.new(options).tap do |cmd|
+          cmd.bootstrap_cwd(base_fork)
+            .perform_merge(git_fork, branch, base_branch, base_fork)
+            .execute
+        end
       end
 
       private

--- a/lib/singularity_dsl/cli/command/test_merge.rb
+++ b/lib/singularity_dsl/cli/command/test_merge.rb
@@ -18,10 +18,19 @@ module SingularityDsl
           @git.verbosity options[:verbose]
         end
 
-        def perform_merge(git_fork, branch, base_branch, base_fork = nil)
-          git.merge_refs git_fork, branch, base_branch, base_fork
-          @diff_list += get_diff_list(base_branch, base_fork)
-          remove_remotes git_fork, base_fork
+        def bootstrap_cwd(repo_url)
+          return self unless options[:bootstrap_cwd]
+          git.clean_reset if git.cwd_is_git_repo
+          git.clone_to_cwd(repo_url) unless git.cwd_is_git_repo
+          git.install_submodules
+          self
+        end
+
+        def perform_merge(fork_url, branch, base_branch, repo_url = nil)
+          git.merge_refs fork_url, branch, base_branch, repo_url
+          git.install_submodules
+          @diff_list += get_diff_list(base_branch, repo_url)
+          remove_remotes fork_url, repo_url
           self
         end
 

--- a/lib/singularity_dsl/git_helper.rb
+++ b/lib/singularity_dsl/git_helper.rb
@@ -15,6 +15,14 @@ module SingularityDsl
       @verbose = false
     end
 
+    def cwd_is_git_repo
+      ::File.exist? "#{::Dir.pwd}/.git"
+    end
+
+    def clone_to_cwd(repo_url)
+      exec("git clone #{repo_url} .")
+    end
+
     def clean_reset
       fail 'failed to clean' unless (reset | clean) == 0
     end
@@ -57,7 +65,6 @@ module SingularityDsl
       checkout_remote base_branch, base_fork
       add_remote git_fork
       merge_remote branch, git_fork
-      install_submodules
     end
 
     def verbosity(level)

--- a/lib/singularity_dsl/version.rb
+++ b/lib/singularity_dsl/version.rb
@@ -2,5 +2,5 @@
 
 # version const for gem
 module SingularityDsl
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/singularity_dsl/cli/command/test_merge_spec.rb
+++ b/spec/singularity_dsl/cli/command/test_merge_spec.rb
@@ -3,9 +3,13 @@
 require 'singularity_dsl/cli/command/test_merge'
 
 describe SingularityDsl::Cli::Command::TestMerge do
+  def create_command(params)
+    SingularityDsl::Cli::Command::TestMerge.new params
+  end
+
   describe '#batch' do
     context ':run_task given' do
-      let(:cmd) { SingularityDsl::Cli::Command::TestMerge.new(run_task: 'foo') }
+      let(:cmd) { create_command(run_task: 'foo') }
 
       it 'returns batch' do
         expect(cmd.batch).to eql 'foo'
@@ -13,10 +17,63 @@ describe SingularityDsl::Cli::Command::TestMerge do
     end
 
     context ':run_task not given' do
-      let(:cmd) { SingularityDsl::Cli::Command::TestMerge.new(run_task: '') }
+      let(:cmd) { create_command(run_task: '') }
 
       it 'returns false when :run_task is an empty string' do
         expect(cmd.batch).to eql false
+      end
+    end
+  end
+
+  describe '#bootstrap_cwd' do
+    let(:repo) { 'fakedood/fakerepo' }
+
+    context ':bootstrap_cwd is false' do
+      let(:cmd) { create_command(bootstrap_cwd: false) }
+
+      it 'does nothing' do
+        allow(cmd.git).to receive :verbosity
+        expect(cmd.bootstrap_cwd repo).to eql cmd
+      end
+    end
+
+    context ':bootstrap_cwd is true' do
+      def expect_git_cmd(cmd)
+        cmd_double = double.as_null_object
+        allow(cmd_double).to receive(:exitstatus).and_return 0
+        expect(::Mixlib::ShellOut)
+          .to receive(:new).with(cmd)
+          .once
+          .and_return(cmd_double)
+      end
+
+      let(:cmd) { create_command(bootstrap_cwd: true) }
+
+      context 'and the cwd is an empty directory' do
+        before :each do
+          allow(::File).to receive(:exist?).and_return(false)
+        end
+
+        it 'attempts clone into local directory' do
+          allow(cmd.git).to receive :verbosity
+          expect_git_cmd("git clone #{repo} .")
+          expect_git_cmd('git submodule update --init --recursive')
+          expect(cmd.bootstrap_cwd repo).to eql cmd
+        end
+      end
+
+      context 'and the cwd is a git directory' do
+        before :each do
+          allow(::File).to receive(:exist?).and_return(true)
+        end
+
+        it 'attempts to clean & reset local' do
+          allow(cmd.git).to receive :verbosity
+          expect_git_cmd('git clean -fdx')
+          expect_git_cmd('git add . && git reset --hard')
+          expect_git_cmd('git submodule update --init --recursive')
+          expect(cmd.bootstrap_cwd repo).to eql cmd
+        end
       end
     end
   end


### PR DESCRIPTION
Jenkins jobs exclusively using the `testmerge` command & workflow can, in theory, just be one line now.