### PR TITLE
tasks/shell_task: disallow null exit codes

### DIFF
--- a/lib/singularity_dsl/tasks/shell_task.rb
+++ b/lib/singularity_dsl/tasks/shell_task.rb
@@ -49,6 +49,7 @@ class ShellTask < SingularityDsl::Task
     command @alternative unless evaluate_conditionals
     @live_stream << log_shell if @live_stream
     @shell.run_command
+    data(@shell.status)
     return 0 if @no_fail
     @shell.exitstatus
   end

--- a/lib/singularity_dsl/tasks/shell_task.rb
+++ b/lib/singularity_dsl/tasks/shell_task.rb
@@ -57,6 +57,10 @@ class ShellTask < SingularityDsl::Task
     'Runs a SH command using Mixlib::ShellOut'
   end
 
+  def failed_status(status)
+    ![0, false].include? status
+  end
+
   private
 
   def log_shell(pre = '', shell = false)


### PR DESCRIPTION
Case where `SIGSEGV` happens.